### PR TITLE
Add California Housing experiment report

### DIFF
--- a/california_plots.py
+++ b/california_plots.py
@@ -1,0 +1,107 @@
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import TensorDataset, DataLoader
+import matplotlib.pyplot as plt
+
+# Load California housing data
+# Columns: longitude, latitude, housing_median_age, total_rooms,
+# total_bedrooms, population, households, median_income, median_house_value
+
+data_path = 'CaliforniaHousing/cal_housing.data'
+data = np.loadtxt(data_path, delimiter=',')
+
+X = data[:, :-1]
+y = data[:, -1:]
+
+# Train-test split
+rng = np.random.default_rng(42)
+indices = rng.permutation(len(X))
+split = int(len(X) * 0.8)
+train_idx, test_idx = indices[:split], indices[split:]
+X_train, X_test = X[train_idx], X[test_idx]
+y_train, y_test = y[train_idx], y[test_idx]
+
+# Standardize features and target
+X_mean, X_std = X_train.mean(axis=0), X_train.std(axis=0)
+y_mean, y_std = y_train.mean(axis=0), y_train.std(axis=0)
+X_train = (X_train - X_mean) / X_std
+X_test = (X_test - X_mean) / X_std
+y_train = (y_train - y_mean) / y_std
+y_test = (y_test - y_mean) / y_std
+
+# Convert to tensors
+tensor_X_train = torch.tensor(X_train, dtype=torch.float32)
+tensor_y_train = torch.tensor(y_train, dtype=torch.float32)
+tensor_X_test = torch.tensor(X_test, dtype=torch.float32)
+tensor_y_test = torch.tensor(y_test, dtype=torch.float32)
+
+train_dataset = TensorDataset(tensor_X_train, tensor_y_train)
+train_loader = DataLoader(train_dataset, batch_size=64, shuffle=True)
+
+# Define neural network
+model = nn.Sequential(
+    nn.Linear(X_train.shape[1], 64),
+    nn.ReLU(),
+    nn.Linear(64, 32),
+    nn.ReLU(),
+    nn.Linear(32, 1)
+)
+
+criterion = nn.MSELoss()
+optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+
+# Training loop with history tracking
+n_epochs = 20
+train_losses = []
+val_losses = []
+for epoch in range(n_epochs):
+    model.train()
+    batch_losses = []
+    for batch_X, batch_y in train_loader:
+        optimizer.zero_grad()
+        outputs = model(batch_X)
+        loss = criterion(outputs, batch_y)
+        loss.backward()
+        optimizer.step()
+        batch_losses.append(loss.item())
+    train_losses.append(np.mean(batch_losses))
+
+    model.eval()
+    with torch.no_grad():
+        val_pred = model(tensor_X_test)
+        val_loss = criterion(val_pred, tensor_y_test).item()
+    val_losses.append(val_loss)
+    print(f"Epoch {epoch+1}/{n_epochs}, Train MSE: {train_losses[-1]:.4f}, Validation MSE: {val_loss:.4f}")
+
+# Final predictions for plotting
+model.eval()
+with torch.no_grad():
+    preds = model(tensor_X_test)
+    preds_orig = preds.numpy() * y_std + y_mean
+    y_test_orig = tensor_y_test.numpy() * y_std + y_mean
+
+# Plot training vs validation MSE
+plt.figure()
+plt.plot(range(1, n_epochs + 1), train_losses, label='Train MSE')
+plt.plot(range(1, n_epochs + 1), val_losses, label='Validation MSE')
+plt.xlabel('Epoch')
+plt.ylabel('MSE')
+plt.title('Training and Validation MSE')
+plt.legend()
+plt.tight_layout()
+plt.savefig('mse_plot.png')
+
+# Plot predicted vs actual values
+plt.figure()
+plt.scatter(y_test_orig, preds_orig, alpha=0.5)
+min_val = min(y_test_orig.min(), preds_orig.min())
+max_val = max(y_test_orig.max(), preds_orig.max())
+plt.plot([min_val, max_val], [min_val, max_val], 'r--')
+plt.xlabel('Actual Median House Value')
+plt.ylabel('Predicted Median House Value')
+plt.title('Actual vs Predicted Values')
+plt.tight_layout()
+plt.savefig('pred_vs_actual.png')
+
+print('Plots saved as mse_plot.png and pred_vs_actual.png')

--- a/informe.doc
+++ b/informe.doc
@@ -1,0 +1,35 @@
+Informe de Experimentos - California Housing
+
+1. Preprocesamiento de datos
+- Carga de los datos mediante `np.loadtxt`.
+- División de los datos en conjuntos de entrenamiento (80%) y prueba (20%) usando una permutación aleatoria fija.
+- Estandarización de cada característica y del objetivo restando la media y dividiendo por la desviación estándar calculada sobre el conjunto de entrenamiento.
+- Conversión de los arreglos a tensores de `torch` y creación de un `DataLoader` con tamaño de lote 64 y barajado de muestras.
+
+Justificación: La estandarización estabiliza el entrenamiento y el `DataLoader` permite optimizar en mini-lotes, lo que mejora la convergencia.
+
+2. Experimento y detalles de los hiperparámetros
+- Arquitectura: red secuencial con capas [8 -> 64 -> 32 -> 1] y funciones de activación ReLU en las capas ocultas.
+- Pérdida: error cuadrático medio (MSE).
+- Optimizador: Adam con tasa de aprendizaje de 0.001.
+- Número de épocas: 20.
+- Tamaño de lote: 64.
+
+3. Resultados de la experimentación
+Tabla de MSE en el conjunto de validación:
+
+Epoch | Val MSE
+5     | 0.2623
+10    | 0.2397
+15    | 0.2334
+20    | 0.2249
+
+Resultados finales sobre el conjunto de prueba:
+- MSE: 2985867125.55
+- R^2: 0.7782
+
+4. Análisis e interpretación
+El MSE de validación disminuye gradualmente, mostrando una mejora constante del modelo. El MSE final sobre el conjunto de prueba indica que las predicciones presentan un error cuadrático medio considerable debido a la escala original del valor de la vivienda, mientras que el R^2 de 0.7782 sugiere que el modelo explica cerca del 78% de la varianza de los precios.
+
+5. Conclusiones
+La red neuronal propuesta logra una capacidad predictiva razonable sobre el conjunto California Housing, aunque podría beneficiarse de ajustes adicionales en la arquitectura o en la regularización para mejorar la generalización. Debido a limitaciones del entorno no se incluyeron gráficos.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 torch
 scikit-learn
+matplotlib


### PR DESCRIPTION
## Summary
- add `informe.doc` with preprocessing steps, hyperparameters, and experimental results for California Housing regression
- add `california_plots.py` to generate training/validation MSE and prediction scatter plots

## Testing
- `python california_regression.py`
- `python california_plots.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68967f3cadd88322947d8fba96e525f1