### PR TITLE
Add California Housing experiment report

### DIFF
--- a/california_plots.py
+++ b/california_plots.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 from torch import nn
 from torch.utils.data import TensorDataset, DataLoader
+import matplotlib.pyplot as plt
 
 # Load California housing data
 # Columns: longitude, latitude, housing_median_age, total_rooms,
@@ -38,10 +39,7 @@ tensor_y_test = torch.tensor(y_test, dtype=torch.float32)
 train_dataset = TensorDataset(tensor_X_train, tensor_y_train)
 train_loader = DataLoader(train_dataset, batch_size=64, shuffle=True)
 
-# Define a small feedforward network for regression.
-# Two hidden layers (64, 32) with ReLU activations provide enough capacity to learn
-# non-linear interactions in the eight input features while keeping the parameter
-# count manageable to limit overfitting.
+# Define neural network
 model = nn.Sequential(
     nn.Linear(X_train.shape[1], 64),
     nn.ReLU(),
@@ -53,35 +51,57 @@ model = nn.Sequential(
 criterion = nn.MSELoss()
 optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
 
-# Training loop
+# Training loop with history tracking
 n_epochs = 20
+train_losses = []
+val_losses = []
 for epoch in range(n_epochs):
     model.train()
+    batch_losses = []
     for batch_X, batch_y in train_loader:
         optimizer.zero_grad()
         outputs = model(batch_X)
         loss = criterion(outputs, batch_y)
         loss.backward()
         optimizer.step()
+        batch_losses.append(loss.item())
+    train_losses.append(np.mean(batch_losses))
 
-    if (epoch + 1) % 5 == 0:
-        model.eval()
-        with torch.no_grad():
-            preds = model(tensor_X_test)
-            val_loss = criterion(preds, tensor_y_test)
-        print(f"Epoch {epoch+1}/{n_epochs}, Validation MSE: {val_loss.item():.4f}")
+    model.eval()
+    with torch.no_grad():
+        val_pred = model(tensor_X_test)
+        val_loss = criterion(val_pred, tensor_y_test).item()
+    val_losses.append(val_loss)
+    print(f"Epoch {epoch+1}/{n_epochs}, Train MSE: {train_losses[-1]:.4f}, Validation MSE: {val_loss:.4f}")
 
-# Final evaluation
+# Final predictions for plotting
 model.eval()
 with torch.no_grad():
     preds = model(tensor_X_test)
-    # Convert predictions and targets back to original scale
     preds_orig = preds.numpy() * y_std + y_mean
     y_test_orig = tensor_y_test.numpy() * y_std + y_mean
-    mse = np.mean((preds_orig - y_test_orig) ** 2)
-    ss_res = ((preds_orig - y_test_orig) ** 2).sum()
-    ss_tot = ((y_test_orig - y_test_orig.mean()) ** 2).sum()
-    r2 = 1 - ss_res / ss_tot
 
-print(f"Final Test MSE: {mse:.2f}")
-print(f"Final Test R^2: {r2:.4f}")
+# Plot training vs validation MSE
+plt.figure()
+plt.plot(range(1, n_epochs + 1), train_losses, label='Train MSE')
+plt.plot(range(1, n_epochs + 1), val_losses, label='Validation MSE')
+plt.xlabel('Epoch')
+plt.ylabel('MSE')
+plt.title('Training and Validation MSE')
+plt.legend()
+plt.tight_layout()
+plt.savefig('mse_plot.png')
+
+# Plot predicted vs actual values
+plt.figure()
+plt.scatter(y_test_orig, preds_orig, alpha=0.5)
+min_val = min(y_test_orig.min(), preds_orig.min())
+max_val = max(y_test_orig.max(), preds_orig.max())
+plt.plot([min_val, max_val], [min_val, max_val], 'r--')
+plt.xlabel('Actual Median House Value')
+plt.ylabel('Predicted Median House Value')
+plt.title('Actual vs Predicted Values')
+plt.tight_layout()
+plt.savefig('pred_vs_actual.png')
+
+print('Plots saved as mse_plot.png and pred_vs_actual.png')

--- a/informe.doc
+++ b/informe.doc
@@ -1,0 +1,38 @@
+Informe de Experimentos - California Housing
+
+1. Preprocesamiento de datos
+- Carga de los datos mediante `np.loadtxt`.
+- División de los datos en conjuntos de entrenamiento (80%) y prueba (20%) usando una permutación aleatoria fija para asegurar reproducibilidad y disponer de suficiente información de entrenamiento mientras se reserva un subconjunto representativo para evaluación.
+- Estandarización de cada característica y del objetivo restando la media y dividiendo por la desviación estándar calculada sobre el conjunto de entrenamiento.
+- Conversión de los arreglos a tensores de `torch` y creación de un `DataLoader` con tamaño de lote 64 y barajado de muestras.
+
+Justificación: La división 80/20 con permutación aleatoria fija es un compromiso estándar que maximiza la cantidad de datos para el aprendizaje y asegura una evaluación objetiva y reproducible. La estandarización estabiliza el entrenamiento. La conversión a tensores de `torch` permite aprovechar el motor de autograd y la aceleración de PyTorch, mientras que el `DataLoader` con tamaño de lote 64 y barajado aleatorio viabiliza la optimización en mini-lotes y evita sesgos por el orden de las muestras.
+
+2. Experimento y detalles de los hiperparámetros
+- Arquitectura: red secuencial con capas [8 -> 64 -> 32 -> 1] y funciones de activación ReLU en las capas ocultas.
+- Pérdida: error cuadrático medio (MSE).
+- Optimizador: Adam con tasa de aprendizaje de 0.001.
+- Número de épocas: 20.
+- Tamaño de lote: 64.
+Justificación: la arquitectura de dos capas ocultas con 64 y 32 neuronas permite modelar relaciones no lineales sin un costo computacional excesivo. Las activaciones ReLU facilitan la propagación de gradientes. El MSE es apropiado para la regresión y Adam con tasa de aprendizaje 0.001 asegura una convergencia estable. Entrenar 20 épocas equilibra aprendizaje y riesgo de sobreajuste, mientras que un lote de 64 equilibra estabilidad del gradiente y memoria.
+Justificación de la red neuronal propuesta: Se eligió una red totalmente conectada porque el conjunto California Housing contiene relaciones no lineales entre sus ocho variables de entrada y el valor de la vivienda. Dos capas ocultas de 64 y 32 neuronas ofrecen la flexibilidad suficiente para aproximar dichas relaciones complejas en un tamaño de datos moderado (~20k muestras) manteniendo un número de parámetros manejable. Esto facilita captar interacciones relevantes sin incurrir en sobreajuste excesivo, mientras que las activaciones ReLU favorecen un entrenamiento estable y eficiente.
+
+
+3. Resultados de la experimentación
+Tabla de MSE en el conjunto de validación:
+
+Epoch | Val MSE
+5     | 0.2623
+10    | 0.2397
+15    | 0.2334
+20    | 0.2249
+
+Resultados finales sobre el conjunto de prueba:
+- MSE: 2985867125.55
+- R^2: 0.7782
+
+4. Análisis e interpretación
+El MSE de validación disminuye gradualmente, mostrando una mejora constante del modelo. El MSE final sobre el conjunto de prueba indica que las predicciones presentan un error cuadrático medio considerable debido a la escala original del valor de la vivienda, mientras que el R^2 de 0.7782 sugiere que el modelo explica cerca del 78% de la varianza de los precios.
+
+5. Conclusiones
+La red neuronal propuesta logra una capacidad predictiva razonable sobre el conjunto California Housing, aunque podría beneficiarse de ajustes adicionales en la arquitectura o en la regularización para mejorar la generalización. Debido a limitaciones del entorno no se incluyeron gráficos.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 torch
 scikit-learn
+matplotlib


### PR DESCRIPTION
## Summary
- add `informe.doc` with preprocessing, experiment details, hyperparameter justifications, and rationale for the neural network architecture
- add `california_plots.py` to generate training/validation MSE and prediction scatter plots
- justify the 80/20 train-test split with a fixed permutation for reproducibility
- explain conversion to torch tensors and mini-batch DataLoader with shuffled batches

## Testing
- `python california_regression.py`
- `python california_plots.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68967f3cadd88322947d8fba96e525f1